### PR TITLE
Added setting to hide the status item

### DIFF
--- a/QuickRadar/AppDelegate.m
+++ b/QuickRadar/AppDelegate.m
@@ -36,15 +36,26 @@
 @synthesize preferencesWindowController = _preferencesWindowController;
 @synthesize applicationHasStarted = _applicationHasStarted;
 
++ (void)initialize
+{
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+     QRShowInStatusBarKey: @YES,
+     }];
+}
+
 #pragma mark NSApplicationDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
-    //setup statusItem
-    statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
-    statusItem.image = [NSImage imageNamed:@"MenubarTemplate"];
-	statusItem.highlightMode = YES;
-    statusItem.menu = self.menu;
+    BOOL shouldShowStatusBarItem = [[NSUserDefaults standardUserDefaults] boolForKey:QRShowInStatusBarKey];
+    
+    if (shouldShowStatusBarItem) {
+        //setup statusItem
+        statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
+        statusItem.image = [NSImage imageNamed:@"MenubarTemplate"];
+        statusItem.highlightMode = YES;
+        statusItem.menu = self.menu;
+    }
 
     //apply hotkey
     [self applyHotkey];

--- a/QuickRadar/QRMainAppSettingsViewController.xib
+++ b/QuickRadar/QRMainAppSettingsViewController.xib
@@ -2,10 +2,10 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">12C60</string>
+		<string key="IBDocument.SystemVersion">12D78</string>
 		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
 			<string key="NS.object.0">3084</string>
@@ -44,6 +44,42 @@
 				<reference key="NSNextResponder"/>
 				<int key="NSvFlags">268</int>
 				<array class="NSMutableArray" key="NSSubviews">
+					<object class="NSButton" id="10488511">
+						<reference key="NSNextResponder" ref="1005"/>
+						<int key="NSvFlags">268</int>
+						<string key="NSFrame">{{182, 135}, {155, 18}}</string>
+						<reference key="NSSuperview" ref="1005"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1049087391"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="NSEnabled">YES</bool>
+						<object class="NSButtonCell" key="NSCell" id="385537824">
+							<int key="NSCellFlags">-2080374784</int>
+							<int key="NSCellFlags2">0</int>
+							<string key="NSContents">Show status bar item</string>
+							<object class="NSFont" key="NSSupport" id="982080446">
+								<string key="NSName">LucidaGrande</string>
+								<double key="NSSize">13</double>
+								<int key="NSfFlags">1044</int>
+							</object>
+							<string key="NSCellIdentifier">_NS:9</string>
+							<reference key="NSControlView" ref="10488511"/>
+							<int key="NSButtonFlags">1211912448</int>
+							<int key="NSButtonFlags2">2</int>
+							<object class="NSCustomResource" key="NSNormalImage" id="915116372">
+								<string key="NSClassName">NSImage</string>
+								<string key="NSResourceName">NSSwitch</string>
+							</object>
+							<object class="NSButtonImageSource" key="NSAlternateImage" id="495571698">
+								<string key="NSImageName">NSSwitch</string>
+							</object>
+							<string key="NSAlternateContents"/>
+							<string key="NSKeyEquivalent"/>
+							<int key="NSPeriodicDelay">200</int>
+							<int key="NSPeriodicInterval">25</int>
+						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+					</object>
 					<object class="NSTextField" id="563308494">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
@@ -57,11 +93,7 @@
 							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">71304192</int>
 							<string key="NSContents">Global hot key:</string>
-							<object class="NSFont" key="NSSupport" id="982080446">
-								<string key="NSName">LucidaGrande</string>
-								<double key="NSSize">13</double>
-								<int key="NSfFlags">1044</int>
-							</object>
+							<reference key="NSSupport" ref="982080446"/>
 							<string key="NSCellIdentifier">_NS:1505</string>
 							<reference key="NSControlView" ref="563308494"/>
 							<object class="NSColor" key="NSBackgroundColor" id="20029051">
@@ -88,9 +120,10 @@
 					<object class="NSPopUpButton" id="639648527">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{181, 101}, {230, 26}}</string>
+						<string key="NSFrame">{{181, 89}, {230, 26}}</string>
 						<reference key="NSSuperview" ref="1005"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSPopUpButtonCell" key="NSCell" id="349588754">
@@ -166,7 +199,7 @@
 					<object class="NSTextField" id="59029691">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{44, 106}, {135, 17}}</string>
+						<string key="NSFrame">{{44, 94}, {135, 17}}</string>
 						<reference key="NSSuperview" ref="1005"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="639648527"/>
@@ -187,7 +220,7 @@
 					<object class="NSTextField" id="1049087391">
 						<reference key="NSNextResponder" ref="1005"/>
 						<int key="NSvFlags">268</int>
-						<string key="NSFrame">{{181, 139}, {298, 14}}</string>
+						<string key="NSFrame">{{181, 121}, {307, 14}}</string>
 						<reference key="NSSuperview" ref="1005"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="59029691"/>
@@ -195,8 +228,8 @@
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="704999462">
 							<int key="NSCellFlags">68157504</int>
-							<int key="NSCellFlags2">138544128</int>
-							<string key="NSContents">This setting takes effect when you restart QuickRadar.</string>
+							<int key="NSCellFlags2">4326400</int>
+							<string key="NSContents">These setting takes effect when you restart QuickRadar.</string>
 							<object class="NSFont" key="NSSupport">
 								<string key="NSName">LucidaGrande</string>
 								<double key="NSSize">11</double>
@@ -215,7 +248,7 @@
 						<string key="NSFrame">{{182, 155}, {121, 18}}</string>
 						<reference key="NSSuperview" ref="1005"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="1049087391"/>
+						<reference key="NSNextKeyView" ref="10488511"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="720886501">
@@ -227,13 +260,8 @@
 							<reference key="NSControlView" ref="495883776"/>
 							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
-							<object class="NSCustomResource" key="NSNormalImage">
-								<string key="NSClassName">NSImage</string>
-								<string key="NSResourceName">NSSwitch</string>
-							</object>
-							<object class="NSButtonImageSource" key="NSAlternateImage">
-								<string key="NSImageName">NSSwitch</string>
-							</object>
+							<reference key="NSNormalImage" ref="915116372"/>
+							<reference key="NSAlternateImage" ref="495571698"/>
 							<string key="NSAlternateContents"/>
 							<string key="NSKeyEquivalent"/>
 							<int key="NSPeriodicDelay">200</int>
@@ -327,6 +355,22 @@
 					</object>
 					<int key="connectionID">96</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBBindingConnection" key="connection">
+						<string key="label">value: values.QRShowInStatusBar</string>
+						<reference key="source" ref="10488511"/>
+						<reference key="destination" ref="989159605"/>
+						<object class="NSNibBindingConnector" key="connector">
+							<reference key="NSSource" ref="10488511"/>
+							<reference key="NSDestination" ref="989159605"/>
+							<string key="NSLabel">value: values.QRShowInStatusBar</string>
+							<string key="NSBinding">value</string>
+							<string key="NSKeyPath">values.QRShowInStatusBar</string>
+							<int key="NSNibBindingConnectorVersion">2</int>
+						</object>
+					</object>
+					<int key="connectionID">418</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -361,9 +405,10 @@
 							<reference ref="563308494"/>
 							<reference ref="920999159"/>
 							<reference ref="495883776"/>
-							<reference ref="1049087391"/>
+							<reference ref="10488511"/>
 							<reference ref="59029691"/>
 							<reference ref="639648527"/>
+							<reference ref="1049087391"/>
 						</array>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -478,6 +523,19 @@
 						<reference key="object" ref="318330974"/>
 						<reference key="parent" ref="563308494"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">415</int>
+						<reference key="object" ref="10488511"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="385537824"/>
+						</array>
+						<reference key="parent" ref="1005"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">416</int>
+						<reference key="object" ref="385537824"/>
+						<reference key="parent" ref="10488511"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -495,6 +553,8 @@
 				<string key="397.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="40.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="415.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="416.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="77.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="78.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="83.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -508,7 +568,7 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">414</int>
+			<int key="maxID">418</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes"/>
 		<int key="IBDocument.localizationMode">0</int>

--- a/QuickRadar/QRUserDefaultsKeys.h
+++ b/QuickRadar/QRUserDefaultsKeys.h
@@ -8,6 +8,7 @@
 
 
 #define QRShowInDockKey @"QRShowInDock"
+#define QRShowInStatusBarKey @"QRShowInStatusBar"
 
 #define QRHandleRdarURLsKey @"QRHandleRdarURLs"
 


### PR DESCRIPTION
Now there is a preference in the preference window to disable the status bar item on launch. This works similarly to the show dock icon setting and has a similar purpose.

The setting is on by default.

Screenshot of preferences: http://cl.ly/image/3I082h2S1U2C
