### PR TITLE
Fixes HTTP redirect issues when posting a second time

### DIFF
--- a/QuickRadar/QRRadarSubmissionService.m
+++ b/QuickRadar/QRRadarSubmissionService.m
@@ -433,7 +433,7 @@
 #if 0
 		dispatch_sync(dispatch_get_main_queue(), ^{
 			self.submissionStatusValue = submissionStatusFailed;
-			completionBlock(NO, [NSError errorWithDomain:@"QRDebugDomain" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Manaully canceled in `submitAsyncWithProgressBlock:`!"}]);
+			completionBlock(NO, [NSError errorWithDomain:@"QRDebugDomain" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Manually canceled in `submitAsyncWithProgressBlock:`!"}]);
 		});
 		return;
 #endif

--- a/QuickRadar/QRRadarSubmissionService.m
+++ b/QuickRadar/QRRadarSubmissionService.m
@@ -120,9 +120,9 @@
 		QRWebScraper *loginPage = [[QRWebScraper alloc] init];
 		loginPage.URL = [NSURL URLWithString:@"https://idmsa.apple.com/IDMSWebAuth/classicLogin.html?appIdKey=77e2a60d4bdfa6b7311c854a56505800be3c24e3a27a670098ff61b69fc5214b&sslEnabled=true&rv=3"];
 
-        // Start with a clean slate. Should be enough to just delete the "myacinfo" cookie,
-        // to fix re-authentication issues, but let's rather make it more predictable by purging all.
-        [loginPage deleteCookies];
+		// Start with a clean slate. Should be enough to just delete the "myacinfo" cookie,
+		// to fix re-authentication issues, but let's rather make it more predictable by purging all.
+		[loginPage deleteCookies];
 
 		if (![loginPage fetch:&error])
 		{

--- a/QuickRadar/QRRadarSubmissionService.m
+++ b/QuickRadar/QRRadarSubmissionService.m
@@ -116,9 +116,9 @@
 		 * Page 1: login page *
 		 **********************/
 		
-        self.submissionStatusText = @"Fetching RadarWeb signin page";
+		self.submissionStatusText = @"Fetching RadarWeb signin page";
 		QRWebScraper *loginPage = [[QRWebScraper alloc] init];
-        loginPage.URL = [NSURL URLWithString:@"https://idmsa.apple.com/IDMSWebAuth/classicLogin.html?appIdKey=77e2a60d4bdfa6b7311c854a56505800be3c24e3a27a670098ff61b69fc5214b&sslEnabled=true&rv=3"];
+		loginPage.URL = [NSURL URLWithString:@"https://idmsa.apple.com/IDMSWebAuth/classicLogin.html?appIdKey=77e2a60d4bdfa6b7311c854a56505800be3c24e3a27a670098ff61b69fc5214b&sslEnabled=true&rv=3"];
 
         // Start with a clean slate. Should be enough to just delete the "myacinfo" cookie,
         // to fix re-authentication issues, but let's rather make it more predictable by purging all.
@@ -429,13 +429,13 @@
 			});
 		}
 
-        // DEBUG: Enable to prevent posting dummy radars if debugging authentication.
+		// DEBUG: Enable to prevent posting dummy radars if debugging authentication.
 #if 0
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            self.submissionStatusValue = submissionStatusFailed;
-            completionBlock(NO, [NSError errorWithDomain:@"QRDebugDomain" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Manaully canceled in `submitAsyncWithProgressBlock:`!"}]);
-        });
-        return;
+		dispatch_sync(dispatch_get_main_queue(), ^{
+			self.submissionStatusValue = submissionStatusFailed;
+			completionBlock(NO, [NSError errorWithDomain:@"QRDebugDomain" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Manaully canceled in `submitAsyncWithProgressBlock:`!"}]);
+		});
+		return;
 #endif
         
         

--- a/QuickRadar/QRRadarSubmissionService.m
+++ b/QuickRadar/QRRadarSubmissionService.m
@@ -425,6 +425,14 @@
 			});
 		}
 
+        // DEBUG: Enable to prevent posting dummy radars if debugging authentication.
+#if 0
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            self.submissionStatusValue = submissionStatusFailed;
+            completionBlock(NO, [NSError errorWithDomain:@"QRDebugDomain" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Manaully canceled in `submitAsyncWithProgressBlock:`!"}]);
+        });
+        return;
+#endif
         
         
         /***************************

--- a/QuickRadar/QRRadarSubmissionService.m
+++ b/QuickRadar/QRRadarSubmissionService.m
@@ -118,8 +118,12 @@
 		
         self.submissionStatusText = @"Fetching RadarWeb signin page";
 		QRWebScraper *loginPage = [[QRWebScraper alloc] init];
-		loginPage.URL = [NSURL URLWithString:@"https://idmsa.apple.com/IDMSWebAuth/classicLogin.html?appIdKey=77e2a60d4bdfa6b7311c854a56505800be3c24e3a27a670098ff61b69fc5214b&sslEnabled=true&rv=3"];
-		
+        loginPage.URL = [NSURL URLWithString:@"https://idmsa.apple.com/IDMSWebAuth/classicLogin.html?appIdKey=77e2a60d4bdfa6b7311c854a56505800be3c24e3a27a670098ff61b69fc5214b&sslEnabled=true&rv=3"];
+
+        // Start with a clean slate. Should be enough to just delete the "myacinfo" cookie,
+        // to fix re-authentication issues, but let's rather make it more predictable by purging all.
+        [loginPage deleteCookies];
+
 		if (![loginPage fetch:&error])
 		{
 			dispatch_sync(dispatch_get_main_queue(), ^{ 

--- a/QuickRadar/QRWebScraper.h
+++ b/QuickRadar/QRWebScraper.h
@@ -27,6 +27,9 @@
 /* A synchronous method */
 - (BOOL)fetch:(NSError**)error;
 
+/* Deletes any cookies currently present. Set the URL before invoking this method. */
+- (BOOL)deleteCookies;
+
 - (NSDictionary*)stringValuesForXPathsDictionary:(NSDictionary*)dict error:(NSError**)error;
 
 @end

--- a/QuickRadar/QRWebScraper.m
+++ b/QuickRadar/QRWebScraper.m
@@ -169,18 +169,18 @@
 
 - (BOOL)deleteCookies
 {
-    NSURL *url = self.URL;
-    NSAssert(url != nil, @"Set the URL before invoking this method.");
+	NSURL *url = self.URL;
+	NSAssert(url != nil, @"Set the URL before invoking this method.");
 
-    BOOL deleted = NO;
-    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSArray<NSHTTPCookie *> *cookies = [storage cookiesForURL:url];
-    for (NSHTTPCookie *cookie in cookies)
-    {
-        [storage deleteCookie:cookie];
-        deleted = YES;
-    }
-    return deleted;
+	BOOL deleted = NO;
+	NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+	NSArray<NSHTTPCookie *> *cookies = [storage cookiesForURL:url];
+	for (NSHTTPCookie *cookie in cookies)
+	{
+		[storage deleteCookie:cookie];
+		deleted = YES;
+	}
+	return deleted;
 }
 
 

--- a/QuickRadar/QRWebScraper.m
+++ b/QuickRadar/QRWebScraper.m
@@ -167,6 +167,23 @@
 }
 
 
+- (BOOL)deleteCookies
+{
+    NSURL *url = self.URL;
+    NSAssert(url != nil, @"Set the URL before invoking this method.");
+
+    BOOL deleted = NO;
+    NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
+    NSArray<NSHTTPCookie *> *cookies = [storage cookiesForURL:url];
+    for (NSHTTPCookie *cookie in cookies)
+    {
+        [storage deleteCookie:cookie];
+        deleted = YES;
+    }
+    return deleted;
+}
+
+
 - (NSDictionary*)stringValuesForXPathsDictionary:(NSDictionary*)dict error:(NSError**)retError;
 {
 //	NSLog(@"Data %@", [[NSString alloc] initWithData:self.returnedData encoding:NSUTF8StringEncoding]);


### PR DESCRIPTION
Fixes #91
Fixes #89 (again)

Deletes all rdar cookies before authenticating. Should fix HTTP redirect issues when posting a second rdar without first restarting the app. 

Note that just deleting the "myacinfo" cookie already seems enough to get it working, but decided to purge everthing in case this changes again in the future.