### PR TITLE
Add support for Two-Factor-Authentication

### DIFF
--- a/QuickRadar/QRWebScraper.h
+++ b/QuickRadar/QRWebScraper.h
@@ -32,4 +32,6 @@
 
 - (NSDictionary*)stringValuesForXPathsDictionary:(NSDictionary*)dict error:(NSError**)error;
 
+@property (nonatomic, strong, readonly) NSString *pageContent;
+
 @end

--- a/QuickRadar/QRWebScraper.m
+++ b/QuickRadar/QRWebScraper.m
@@ -216,5 +216,8 @@
 	return returnDict;
 }
 
+- (NSString *)pageContent {
+    return self.xmlDocument.stringValue;
+}
 
 @end


### PR DESCRIPTION
This PR adds support for two-factor authentication. This should close #86, even if the ticket mentions two-step-auth; which is super confusing a different, older 2-* auth variant from Apple.

Most people will use the modern one that pops up an alert.

This now works with my account, but should be tested with a few more people.

This uses API that's 10.9 and higher, I assume that's fine? AppKit is already dirty enough :)

Binary (DEBUG release, but performance doesn't really matter here)
https://cl.ly/102644223v3y

*Please help test this and report if it works in the comments*