### PR TITLE
add "rdar://" prefix for cilpboard number

### DIFF
--- a/QuickRadar/QRCopyToClipboardSubmissionService.m
+++ b/QuickRadar/QRCopyToClipboardSubmissionService.m
@@ -83,7 +83,7 @@
 
 - (void)submitAsyncWithProgressBlock:(void (^)())progressBlock completionBlock:(void (^)(BOOL, NSError *))completionBlock
 {
-	NSString *radarNumString = [NSString stringWithFormat:@"%li", self.radar.radarNumber];
+	NSString *radarNumString = [NSString stringWithFormat:@"rdar://%li", self.radar.radarNumber];
 	
 	[[NSPasteboard generalPasteboard] clearContents];
 	[[NSPasteboard generalPasteboard] writeObjects:@[radarNumString]];


### PR DESCRIPTION
I've never find the raw radar number useful anywhere. This PR prefixes the
number copied to clipboard with `rdar://` to save user from adding the manually
after pasting.